### PR TITLE
Added Dockerfile and changed sugar path on solverOrderBased

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get upgrade \ 
+    && apt-get install -y python3 wget unzip default-jre make cmake libz-dev g++ git minisat python-pip
+
+# Install sugar   
+RUN wget http://bach.istc.kobe-u.ac.jp/sugar/package/sugar-v2-3-3.zip -P /tmp \
+    && cd /tmp \
+    && unzip sugar-v2-3-3.zip \
+    && cd /tmp/sugar-v2-3-3/ \
+    && mkdir -p /usr/local/lib/sugar/ \
+    && mv /tmp/sugar-v2-3-3/bin/sugar-v2-3-3.jar /usr/local/lib/sugar/sugar-v2-3-3.jar \
+    && mv /tmp/sugar-v2-3-3/bin/sugar /bin/
+
+# Install glucose
+RUN wget https://www.labri.fr/perso/lsimon/downloads/softwares/glucose-syrup-4.1.tgz -P /tmp \
+    && cd /tmp \
+    && tar -xzf /tmp/glucose-syrup-4.1.tgz  \
+    && cd /tmp/glucose-syrup-4.1/simp \
+    && make rs \
+    && mv glucose* /bin/glucose
+
+RUN cd /tmp && rm -rf * 
+
+COPY . /app
+WORKDIR /app
+
+# Install python libraries
+RUN pip install -r requirements.txt
+
+ENTRYPOINT python main.pyc 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Example run:
 
 We have tested the tool on both Ubuntu 17.10 and 18.04. However, it should be fine in any Debian based linux distrubition machine. 
 
+**Development**
+
+Build the tool by typing 
+```bash
+docker build --tag ucit .
+```
+
+Run the tool by typing 
+```bash 
+docker run --rm -i -t ucit -m 1 -s solverUsageBased -i ./sampleInputFiles/usageBasedStudy.inFile
+```
 
 **Input File Format**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+satispy
+numpy

--- a/solverOrderBased.py
+++ b/solverOrderBased.py
@@ -1,6 +1,6 @@
 from os import popen
 
-SUGAR_CMD = "/home/hanefimercan/sugar/bin/sugar"
+SUGAR_CMD = "sugar"
 
 def _solve(systemConstraints, entityConstraints):
     outFile = open("temp.csp", "w")


### PR DESCRIPTION
Since the tool compiled on a linux machine and I cannot run it on MacOS, I wrote a Dockerfile to run it on every machine without any hassle. However, the point is that I couldn't map the volume of my input folder to the folder in the container. I am still looking to the documentation about it. If you find how to map the volume to pass input files to a docker container, please let me know.  It must be very similar to the command below (using -v flag).

`docker run --rm -i -t -v /Users/oguzozsaygin/oguzozsaygin/code/UCIT/sampleInputFiles:/tmp/work ucit -m 1 -s solverUsageBased -i /tmp/work/usageBasedStudy.inFile`
